### PR TITLE
incremental scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ NOTE: This service can replace the download-url-service && harvest-collector-ser
 ### Configuration
 The following environment variales can be configured:
 * `DEFAULT_GRAPH`: graph to write the download event and file to
+* `INCREMENTAL_RETRIEVAL`: (default: `false`) for scheduled jobs check result of previous succesfull executions and don't refetch all documents on each execution. 
 
 ### Model
 The service is triggered by updates of resources of type `nfo:RemoteDataObject` of which the status is updated to `http://lblod.data.gift/file-download-statuses/ready-to-be-cached`. It will download the associated URL (`nie:url`) as file.
@@ -72,6 +73,15 @@ The model of this service is compliant with the model of the [file-service](http
 the service exposes an endpoint `/scrape` that you can `POST` to. the provided URL (query param `url`) is used as the start_url to scrape from.
 
 ## Things worth mentioning
+
+### RDFa support
 The scraper doesn't actually parse rdfa but uses heuristics to find relevant links. This is a lot faster than parsing the RDFa
 Testing with about 100 "gemeenten" indicates this works well enough for now, but we might want to parse RDFa if required.
+
+### Incremental retrieval
+This relies on making a distinction between overview pages and actual documents and currently heavily relies on the specified document types via the "typeof" attribute. If a matching document type is not found the page will be refetched every time
+In addition 10% of previously fetched pages are refetched each run to avoid revisiting all pages if executions move outside of our interval (currently +- 30 days)
+Currently we only check previous executions of a scheduled job, so a manually triggered job will always index everything. If you remove and recreate a scheduled job this will also trigger a reindex of everyting.
+
+
 

--- a/lblod/harvester.py
+++ b/lblod/harvester.py
@@ -7,6 +7,8 @@ import uuid
 import datetime
 import re
 from urllib.parse import urldefrag
+import random
+
 
 from constants import DEFAULT_GRAPH, RESOURCE_BASE, FILE_STATUSES
 
@@ -17,7 +19,7 @@ def ensure_remote_data_object(collection, url):
     else:
         return create_remote_data_object(collection, url)
 
-def cleanUrl(url):
+def clean_url(url):
     """
     Workaround to avoid extracting the same url multiple times because a `jsessionid`
     is set in the url. This is only relevant for urls using a Java backend.
@@ -57,7 +59,7 @@ def create_remote_data_object(collection, url):
         graph = sparql_escape_uri(DEFAULT_GRAPH),
         uri = sparql_escape_uri(uri),
         uuid = sparql_escape_string(uuid),
-        url = sparql_escape_uri(cleanUrl(url)),
+        url = sparql_escape_uri(clean_url(url)),
         status = sparql_escape_uri(FILE_STATUSES['READY']),
         created = sparql_escape_datetime(created),
         modified = sparql_escape_datetime(created),
@@ -71,6 +73,110 @@ def create_remote_data_object(collection, url):
         'uri': uri,
         'status': FILE_STATUSES['READY']
     }
+
+def get_previous_succesfull_jobs(task_uri, max_age_in_days = 30):
+    query_t = Template("""
+    PREFIX cogs: <http://vocab.deri.ie/cogs#>
+    PREFIX    adms: <http://www.w3.org/ns/adms#>
+    PREFIX    dct: <http://purl.org/dc/terms/>
+    SELECT ?olderJob WHERE {
+      GRAPH $graph {
+         $task dct:isPartOf ?job.
+         ?job dct:creator ?scheduledJob.
+         ?scheduledJob a <http://vocab.deri.ie/cogs#ScheduledJob>.
+         ?olderJob dct:creator ?scheduledJob.
+         ?olderJob dct:modified ?modified.
+         ?olderJob adms:status <http://redpencil.data.gift/id/concept/JobStatus/success>.
+         FILTER (?modified > NOW() - $intervalInSeconds)
+      }
+    }
+    """)
+    query_s = query_t.substitute(
+        graph = sparql_escape_uri(DEFAULT_GRAPH),
+        task = sparql_escape_uri(task_uri),
+        intervalInSeconds = max_age_in_days * 86400
+    )
+    results = query_sudo(query_s)
+    bindings = results["results"]["bindings"]
+    jobs = map(lambda b: b["olderJob"]["value"], bindings)
+    return jobs
+
+def count_previous_urls(jobs):
+    query_t = Template("""
+        PREFIX tasks: <http://redpencil.data.gift/vocabularies/tasks/>
+        PREFIX    dct: <http://purl.org/dc/terms/>
+        PREFIX    nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+        SELECT (COUNT(DISTINCT(?url)) as ?count) WHERE {
+          GRAPH $graph {
+            VALUES ?job {
+              $jobs
+            }
+            ?task dct:isPartOf ?job;
+                  tasks:operation <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>;
+                  tasks:resultsContainer/tasks:hasFile ?file.
+            ?file nie:url ?url;
+                  dct:type ?type.
+            FILTER(?type != <http://schema.org/WebPage>)
+        }
+        }
+        """)
+
+    query_s = query_t.substitute(
+        graph = sparql_escape_uri(DEFAULT_GRAPH),
+        jobs = "\n".join(map(lambda j: sparql_escape_uri(j), jobs)),
+    )
+    results = query_sudo(query_s)
+    bindings = results["results"]["bindings"]
+    count = bindings[0]["count"]["value"]
+    logger.info(f"found {count} previously harvested urls that should not be harvested again")
+    return int(count)
+
+def get_previous_pages(task_uri):
+    jobs = list(get_previous_succesfull_jobs(task_uri))
+    if len(jobs) > 0:
+        nb_urls= count_previous_urls(jobs)
+        offset = 0
+        urls = []
+        while offset < nb_urls:
+            query_t = Template("""
+            PREFIX tasks: <http://redpencil.data.gift/vocabularies/tasks/>
+            PREFIX    dct: <http://purl.org/dc/terms/>
+            PREFIX    nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+            SELECT ?url WHERE {
+              SELECT DISTINCT ?url {
+                GRAPH $graph {
+                  VALUES ?job {
+                    $jobs
+                  }
+                  ?task dct:isPartOf ?job;
+                  tasks:operation <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>;
+                  tasks:resultsContainer/tasks:hasFile ?file.
+                  ?file nie:url ?url;
+                  dct:type ?type.
+                  FILTER(?type != <http://schema.org/WebPage>)
+               }
+            } ORDER BY ?url
+        } LIMIT 5000 OFFSET $offset
+        """)
+
+            query_s = query_t.substitute(
+                graph = sparql_escape_uri(DEFAULT_GRAPH),
+                jobs = "\n".join(map(lambda j: sparql_escape_uri(j), jobs)),
+                offset = offset
+            )
+            results = query_sudo(query_s)
+            bindings = results["results"]["bindings"]
+            for b in bindings:
+                urls.append(b["url"]["value"])
+            offset = offset + 5000
+        return urls
+    return []
+
+def remove_random_10_percent_of_list(input_list):
+    num_elements_to_remove = int(len(input_list) * 0.1)
+    elements_to_remove = random.sample(input_list, num_elements_to_remove)
+    updated_list = [item for item in input_list if item not in elements_to_remove]
+    return updated_list
 
 def count_number_of_files_in_collection(collection_uri):
         query_template = Template("""
@@ -183,7 +289,7 @@ def get_remote_data_object(collection_uri, remote_url):
     query_string = query_template.substitute(
         graph = sparql_escape_uri(DEFAULT_GRAPH),
         collection = sparql_escape_uri(collection_uri),
-        url = sparql_escape_uri(cleanUrl(remote_url))
+        url = sparql_escape_uri(clean_url(remote_url))
     )
     results = query_sudo(query_string)
     bindings = results["results"]["bindings"]


### PR DESCRIPTION
only scrape pages that weren't scraped recently. 
This relies on making a distinction between overview pages and actual documents and currently heavily relies on the specified document types via the "typeof" attribute. If a matching document type is not found the page will be re-fetched every time
In addition 10% of previously fetched pages are refetched each run to avoid revisiting all pages if executions move outside of our interval (currently +- 30 days)
Currently we only check previous executions of a scheduled job, so a manually triggered job will always index everything. If you remove and recreate a scheduled job this will also trigger a reindex of everyting. 

NOTE: this still has some things (like max_age) hardcoded that should be improved later on.