### PR TITLE
allow storing only interesting pages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,5 @@ ENV AUTO_RUN="false"
 ENV DEFAULT_GRAPH="http://mu.semte.ch/graphs/scraper-graph"
 ENV PYTHONUNBUFFERED="1"
 ENV IN_DOCKER="true"
+ENV STORE_ALL_PAGES="true"
 COPY scrapy.cfg /usr/src/app

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ NOTE: This service can replace the download-url-service && harvest-collector-ser
 The following environment variales can be configured:
 * `DEFAULT_GRAPH`: graph to write the download event and file to
 * `INCREMENTAL_RETRIEVAL`: (default: `false`) for scheduled jobs check result of previous succesfull executions and don't refetch all documents on each execution. 
+* `STORE_ALL_PAGES`: (default: `true`) when disabled (`false`) will only store pages containing Notulen, Agenda, Besluitenlijst, Uittreksel, Besluit or BehandelingVanAgendapunt. (using the same heuristic as incremantal retrieval).
 
 ### Model
 The service is triggered by updates of resources of type `nfo:RemoteDataObject` of which the status is updated to `http://lblod.data.gift/file-download-statuses/ready-to-be-cached`. It will download the associated URL (`nie:url`) as file.

--- a/lblod/spiders/lblod.py
+++ b/lblod/spiders/lblod.py
@@ -65,7 +65,6 @@ class LBLODSpider(Spider):
                 if not href.endswith('.pdf'):
                     url = response.urljoin(href)
                     if not clean_url(url) in self.previous_collected_pages:
-                        ensure_remote_data_object(self.collection, url)
                         yield response.follow(url)
                     else:
                         logger.info(f"ignoring previously harvested url {url}")

--- a/lblod/spiders/lblod.py
+++ b/lblod/spiders/lblod.py
@@ -1,3 +1,4 @@
+import os
 from scrapy import Spider
 from scrapy.loader import ItemLoader
 from scrapy.http.response.text import TextResponse
@@ -10,6 +11,15 @@ from lblod.harvester import ensure_remote_data_object, clean_url
 
 BESLUIT = Namespace("http://data.vlaanderen.be/ns/besluit#")
 LBBESLUIT = Namespace("http://lblod.data.gift/vocabularies/besluit/")
+GENERAL_PAGE_TYPE = 'http://schema.org/WebPage'
+INTERESTING_PROPERTIES = [
+    'heeftNotulen',
+    'heeftAgenda',
+    'heeftBesluitenlijst',
+    'heeftUittreksel',
+    'linkToPublication'
+]
+STORE_ALL_PAGES = os.getenv("STORE_ALL_PAGES") in ["yes", "on", "true", True, "1", 1]
 
 def doc_type_from_type_ofs(type_ofs):
     # notulen, agenda, besluitenlijst uittreksel
@@ -28,7 +38,7 @@ def doc_type_from_type_ofs(type_ofs):
         if 'Besluit' in type_of or 'BehandelingOfAgendapunt' in type_of:
             return 'https://schema.org/ItemPage'
     # Else return general webpage type
-    return 'http://schema.org/WebPage'
+    return GENERAL_PAGE_TYPE
 
 class LBLODSpider(Spider):
     name = "LBLODSpider"
@@ -37,26 +47,21 @@ class LBLODSpider(Spider):
             raise IgnoreRequest("ignoring non text response")
 
         # store page itself
-        rdo = ensure_remote_data_object(self.collection, response.url)
         type_ofs = response.xpath('//@typeof').getall()
         doc_type = doc_type_from_type_ofs(type_ofs)
-        page = ItemLoader(item=Page(), response=response)
-        page.add_value("url", response.url)
-        page.add_value("contents", response.text)
-        page.add_value("rdo", rdo)
-        page.add_value("doc_type", doc_type)
-        yield page.load_item()
-        interesting_properties = [
-            'heeftNotulen',
-            'heeftAgenda',
-            'heeftBesluitenlijst',
-            'heeftUittreksel',
-            'linkToPublication'
-        ]
+        if doc_type != GENERAL_PAGE_TYPE or STORE_ALL_PAGES:
+            rdo = ensure_remote_data_object(self.collection, response.url)
+            page = ItemLoader(item=Page(), response=response)
+            page.add_value("url", response.url)
+            page.add_value("contents", response.text)
+            page.add_value("rdo", rdo)
+            page.add_value("doc_type", doc_type)
+            yield page.load_item()
+
         for element in response.xpath('//a[@href and @property]'):
             href = element.xpath('@href').get()
             property_value = element.xpath('@property').get()
-            if any(value in property_value for value in interesting_properties):
+            if any(value in property_value for value in INTERESTING_PROPERTIES):
                 if not href.endswith('.pdf'):
                     url = response.urljoin(href)
                     if not clean_url(url) in self.previous_collected_pages:


### PR DESCRIPTION
this allows us to only store interesting pages, but a downside is we no longer store pages before we scrape them. this means the check-url service will not really do anything useful anymore (and perhaps that step can be removed)