### PR TITLE
fix cycle in crawl

### DIFF
--- a/lblod/spiders/lblod.py
+++ b/lblod/spiders/lblod.py
@@ -63,8 +63,8 @@ class LBLODSpider(Spider):
             property_value = element.xpath('@property').get()
             if any(value in property_value for value in INTERESTING_PROPERTIES):
                 if not href.endswith('.pdf'):
-                    url = response.urljoin(href)
-                    if not clean_url(url) in self.previous_collected_pages:
+                    url = clean_url(response.urljoin(href))
+                    if not url in self.previous_collected_pages:
                         yield response.follow(url)
                     else:
                         logger.info(f"ignoring previously harvested url {url}")


### PR DESCRIPTION
Antwerp should only have around  ~7500~ (edit: probably more) pages to scrape. However, the last time I checked, there were over 500k pages.

I believe the reason for this is that Antwerp adds a dynamic ;jsessionid segment to their urls. When we follow these links, the scraper adds automatically the dynamic jsessionid in its list of visited urls. This results in many variations of the same URL being treated as different pages, potentially creating a crawl loop.

This PR should resolve the issue, as it ensures we clean the url before following it.
